### PR TITLE
Make onInit optional in types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -180,7 +180,7 @@ declare module "typewriter-effect" {
   }
 
   const TypewriterComponent: React.FunctionComponent<{
-    onInit(typewriter: TypewriterClass): void
+    onInit?: (typewriter: TypewriterClass) => void
     options?: Partial<Options>
   }>
 


### PR DESCRIPTION
The readme indicates that `onInit` is an optional prop, but the typescript types do not reflect this.