### PR TITLE
add react component typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -182,6 +182,10 @@ declare module "typewriter-effect" {
   const TypewriterComponent: React.FunctionComponent<{
     onInit?: (typewriter: TypewriterClass) => void
     options?: Partial<Options>
+    /**
+     * The component to use as a container. Defaults to "div".
+     */
+    component?: React.Component | string
   }>
 
   export default TypewriterComponent


### PR DESCRIPTION
Adds a typing for `ReactComponent.component`, since it was not defined before.

https://github.com/tameemsafi/typewriterjs/blob/e50a407493caee8512b417c031ffe919ed1e4889/src/react/Typewriter.js#L52-L54

Also specifies the default, which was implemented here:

https://github.com/tameemsafi/typewriterjs/blob/e50a407493caee8512b417c031ffe919ed1e4889/src/react/Typewriter.js#L67-L69