### PR TITLE
widen peer dependency to include React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "test": "jest --env=jsdom"
   },
   "peerDependencies": {
-    "react": "16.x",
-    "react-dom": "16.x"
+    "react": "^16 || ^17",
+    "react-dom": "^16 || ^17"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.5",


### PR DESCRIPTION
fix warnings for those using React 17:

```raw
typewriter-effect@2.18.0" has incorrect peer dependency "react@16.x".
typewriter-effect@2.18.0" has incorrect peer dependency "react-dom@16.x".
```
