### PR TITLE
add ommited type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,12 @@ declare module "typewriter-effect" {
      */
     autoStart?: boolean
     /**
+     * The pause duration after a string is typed when using autostart mode
+     * 
+     * @default 1500
+     */
+     pauseFor?: number
+    /**
      * Whether or not to display console logs.
      *
      * @default false


### PR DESCRIPTION
While using the module, I tried using the `pauseFor` attribute in typescript but I get a compilation error because the type is not defined. Although the attribute worked,  I had to use `//@ts-ignore` just to get rid of the error.

It also seems that there are inconsistencies in the method section of the type definition in comparison to the readME file. I don't really know which of them is right so I didn't touch it.