### PR TITLE
Add component prop to types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -182,6 +182,7 @@ declare module "typewriter-effect" {
   const TypewriterComponent: React.FunctionComponent<{
     onInit?: (typewriter: TypewriterClass) => void
     options?: Partial<Options>
+    component?: 'div' | 'span'
   }>
 
   export default TypewriterComponent


### PR DESCRIPTION
I am using the react component with `component='span'` but Typescript complains because the prop is missing. After adding this one line it works like a charm.