### PR TITLE
Fix stringSplitter option type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -68,7 +68,7 @@ declare module "typewriter-effect" {
      * 
      * @default null
      */
-    stringSplitter?: (text: string) => string
+    stringSplitter?: (text: string) => string[]
     /**
      * Callback function to replace the internal method which
      * creates a text node for the character before adding


### PR DESCRIPTION
#### This pull request aims to fix stringSplitter's option type

`stringSplitter` option accepts a callback function with a return type of **array of strings**

Refer to `src\core\Typewriter.js` line `201`
```javascript
if(string) {
  const { stringSplitter } = this.options || {};
  const characters = typeof stringSplitter === 'function' ? stringSplitter(string) : string.split('');
  this.typeCharacters(characters, node);
}
```

Fix: change the return type delcared in `index.d.ts` at line `71`
```diff
- stringSplitter?: (text: string) => string
+ stringSplitter?: (text: string) => string[]
```