### PR TITLE
Added pauseFor property to Options interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,12 @@ declare module "typewriter-effect" {
      */
     autoStart?: boolean
     /**
+     * The pause duration after a string is typed when using autostart mode.
+     * 
+     * @default 1500
+     */
+    pauseFor?: number
+    /**
      * Whether or not to display console logs.
      *
      * @default false


### PR DESCRIPTION
The Options interface in the types file is missing the pauseFor property, causing Typescript to disallow the property to be added to the Options object. 

I added the pauseFor property to the interface, so now it should be able to resolve the property.