### PR TITLE
Fix the TypeScript definition for stringSplitter function to properly reflect it returns an array of strings instead of a single string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -68,7 +68,7 @@ declare module "typewriter-effect" {
      * 
      * @default null
      */
-    stringSplitter?: (text: string) => string
+    stringSplitter?: (text: string) => string[]
     /**
      * Callback function to replace the internal method which
      * creates a text node for the character before adding


### PR DESCRIPTION
Update the TypeScript definition for stringSplitter function to properly reflect it returns an array of strings instead of a single string. This aligns with the intended usage for splitting emoji/text into multiple parts.