### PR TITLE
Check parentNode is not null before removing child

### DIFF
--- a/src/core/Typewriter.js
+++ b/src/core/Typewriter.js
@@ -685,7 +685,7 @@ class Typewriter {
             })
           }
 
-          if(node) {
+          if(node && node.parentNode) {
             node.parentNode.removeChild(node);
           }
           


### PR DESCRIPTION
We started seeing this error on our sentry dashboard coming from the Typewriter package:
`Cannot read properties of null (reading 'removeChild')`

<img width="1926" height="230" alt="image" src="https://github.com/user-attachments/assets/532c9e59-dca8-404c-9e8f-f6b479800213" />

The fix is to check `parentNode` is not null before calling the `removeChild` method on it.

I think it's caused by a translation browser plugin (changing/removing/inserting text nodes) since only a few users are receiving this error.